### PR TITLE
Jekyll config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: "AB-3"
+title: "LingoGO!"
 theme: minima
 
 header_pages:
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2122S1-CS2103T-T11-2/tp"
 github_icon: "images/github-icon.png"
 
 plugins:

--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "LingoGO!";
     font-size: 32px;
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: AddressBook Level-3
+title: LingoGO!
 ---
 
 [![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)


### PR DESCRIPTION
Updated project name and repo link. Closes #9.

Preview deployment: https://3ed7a09c.tp-b32.pages.dev/

To test:
- [ ] Website navbar title is changed to LingoGO!
- [ ] GitHub icon leads to this repository