### PR TITLE
Test command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -44,7 +44,7 @@ LingoGO! is a **desktop app for university students who use English as their fir
 
    * **`flip`**`2`: Toggles the 2nd flashcard to hide or show the correct English phrase.
 
-   * **`test`**`17`**`hello`**: Checks flashcard 17's English phrase against the word **`hello`** and then shows
+   * **`test`**`17`**`e/hello`**: Checks the 17th flashcard's English phrase against the word **`hello`** and then shows
      whether it is correct.
 
 
@@ -203,7 +203,7 @@ Examples:
 
 Checks whether the English phrase of a flashcard matches a given phrase.
 
-Format: `test INDEX ENGLISH_PHRASE`
+Format: `test INDEX e/ENGLISH_PHRASE`
 
 * Checks the English phrase of the flashcard at the specified `INDEX` with the given `ENGLISH_PHRASE`.
 * The app will then show user the correct English phrase and tell the user whether he got it right.
@@ -213,7 +213,7 @@ Format: `test INDEX ENGLISH_PHRASE`
 * `ENGLISH_PHRASE` is not case-sensitive (e.g. "HeLLo" matches "hello").
 
 Examples:
-* `test 4 hello` checks the 4th card on display to see if `hello` matches the English phrase of the flashcard.
+* `test 4 e/hello` checks the 4th card on display to see if `hello` matches the English phrase of the flashcard.
 
 ### Saving the data
 
@@ -251,5 +251,5 @@ Action | Format, Examples
 **Download** | `download FILE_NAME`<br> e.g., `download myCards.csv`
 **Help** | `help`
 **Flip** | `flip INDEX` <br> e.g.,  `flip 2`
-**Test** | `test INDEX ENGLISH_PHRASE` <br> e.g.,  `test 17 hello`
+**Test** | `test INDEX e/ENGLISH_PHRASE` <br> e.g., `test 17 e/hello`
 **Exit** | `exit`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -205,7 +205,7 @@ Checks whether the English phrase of a flashcard matches a given phrase.
 
 Format: `test INDEX e/ENGLISH_PHRASE`
 
-* Checks the English phrase of the flashcard at the specified `INDEX` with the given `ENGLISH_PHRASE`.
+* Checks the English phrase of the flashcard at the specified `INDEX` against the given `ENGLISH_PHRASE`.
 * The app will then show user the correct English phrase and tell the user whether he got it right.
 * The index refers to the index number shown in the current displayed list.
 * The index **must be a positive integer** 1, 2, 3, …

--- a/src/main/java/lingogo/logic/commands/TestCommand.java
+++ b/src/main/java/lingogo/logic/commands/TestCommand.java
@@ -1,0 +1,79 @@
+package lingogo.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import lingogo.commons.core.Messages;
+import lingogo.commons.core.index.Index;
+import lingogo.logic.commands.exceptions.CommandException;
+import lingogo.model.Model;
+import lingogo.model.flashcard.EnglishPhraseMatchesGivenPhrasePredicate;
+import lingogo.model.flashcard.Flashcard;
+import lingogo.model.flashcard.Phrase;
+
+/**
+ * Checks whether the English phrase of a flashcard matches a given phrase.
+ */
+public class TestCommand extends Command {
+
+    public static final String COMMAND_WORD = "test";
+    public static final String COMMAND_DESCRIPTION = "Checks whether the English phrase of a flashcard"
+        + " matches a given phrase";
+    public static final String COMMAND_USAGE = "test INDEX e/ENGLISH_PHRASE";
+    public static final String COMMAND_EXAMPLES = "test 4 e/hello";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Checks whether the English phrase of a flashcard matches a given phrase.\n"
+        + "Parameters: INDEX (must be a positive integer) e/ENGLISH_PHRASE\n"
+        + "Example: " + COMMAND_EXAMPLES;
+
+    private static final String COMPARISON_TEXT = "Foreign Phrase: %1$s\n" + "Expected answer: %2$s\n"
+        + "Your answer: %3$s";
+
+    public static final String MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT = "Well done! You got it right!\n"
+        + COMPARISON_TEXT;
+
+    public static final String MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG = "Oh no! You got it wrong!\n" + COMPARISON_TEXT;
+
+    private final Index targetIndex;
+    private final EnglishPhraseMatchesGivenPhrasePredicate predicate;
+    private final Phrase givenPhrase;
+
+    /**
+     * @param targetIndex of the flashcard in the displayed flashcard list to test
+     * @param givenPhrase to test for match with the flashcard's English Phrase
+     */
+    public TestCommand(Index targetIndex, Phrase givenPhrase) {
+        this.targetIndex = targetIndex;
+        this.predicate = new EnglishPhraseMatchesGivenPhrasePredicate(givenPhrase);
+        this.givenPhrase = givenPhrase;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Flashcard> lastShownList = model.getFilteredFlashcardList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX);
+        }
+
+        Flashcard flashcardToTest = lastShownList.get(targetIndex.getZeroBased());
+
+        if (!predicate.test(flashcardToTest)) {
+            return new CommandResult(String.format(MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG,
+                flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), givenPhrase));
+        }
+        return new CommandResult(String.format(MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
+            flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), givenPhrase));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof TestCommand // instanceof handles nulls
+            && targetIndex.equals(((TestCommand) other).targetIndex)
+            && givenPhrase.equals(((TestCommand) other).givenPhrase)); // state check
+    }
+}

--- a/src/main/java/lingogo/logic/parser/FlashcardAppParser.java
+++ b/src/main/java/lingogo/logic/parser/FlashcardAppParser.java
@@ -15,6 +15,7 @@ import lingogo.logic.commands.ExitCommand;
 import lingogo.logic.commands.FindCommand;
 import lingogo.logic.commands.HelpCommand;
 import lingogo.logic.commands.ListCommand;
+import lingogo.logic.commands.TestCommand;
 import lingogo.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class FlashcardAppParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TestCommand.COMMAND_WORD:
+            return new TestCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/lingogo/logic/parser/TestCommandParser.java
+++ b/src/main/java/lingogo/logic/parser/TestCommandParser.java
@@ -1,0 +1,41 @@
+package lingogo.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static lingogo.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static lingogo.logic.parser.CliSyntax.PREFIX_ENGLISH_PHRASE;
+
+import lingogo.commons.core.index.Index;
+import lingogo.logic.commands.TestCommand;
+import lingogo.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new TestCommand object
+ */
+public class TestCommandParser implements Parser<TestCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the TestCommand
+     * and returns a TestCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TestCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ENGLISH_PHRASE);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TestCommand.MESSAGE_USAGE), pe);
+        }
+
+        if (!argMultimap.getValue(PREFIX_ENGLISH_PHRASE).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TestCommand.MESSAGE_USAGE));
+        }
+
+        return new TestCommand(index, ParserUtil.parsePhrase(argMultimap.getValue(PREFIX_ENGLISH_PHRASE).get()));
+    }
+
+}

--- a/src/main/java/lingogo/model/flashcard/EnglishPhraseContainsKeywordsPredicate.java
+++ b/src/main/java/lingogo/model/flashcard/EnglishPhraseContainsKeywordsPredicate.java
@@ -5,6 +5,9 @@ import java.util.function.Predicate;
 
 import lingogo.commons.util.StringUtil;
 
+/**
+ * A {@code Predicate} which tests a given {@code Flashcard} against a list of given keywords.
+ */
 public class EnglishPhraseContainsKeywordsPredicate implements Predicate<Flashcard> {
     private final List<String> keywords;
 

--- a/src/main/java/lingogo/model/flashcard/EnglishPhraseMatchesGivenPhrasePredicate.java
+++ b/src/main/java/lingogo/model/flashcard/EnglishPhraseMatchesGivenPhrasePredicate.java
@@ -2,6 +2,9 @@ package lingogo.model.flashcard;
 
 import java.util.function.Predicate;
 
+/**
+ * A {@code Predicate} which tests whether a given {@code Flashcard}'s English phrase matches the given phrase.
+ */
 public class EnglishPhraseMatchesGivenPhrasePredicate implements Predicate<Flashcard> {
     private final Phrase givenPhrase;
 

--- a/src/main/java/lingogo/model/flashcard/EnglishPhraseMatchesGivenPhrasePredicate.java
+++ b/src/main/java/lingogo/model/flashcard/EnglishPhraseMatchesGivenPhrasePredicate.java
@@ -1,0 +1,23 @@
+package lingogo.model.flashcard;
+
+import java.util.function.Predicate;
+
+public class EnglishPhraseMatchesGivenPhrasePredicate implements Predicate<Flashcard> {
+    private final Phrase givenPhrase;
+
+    public EnglishPhraseMatchesGivenPhrasePredicate(Phrase givenPhrase) {
+        this.givenPhrase = givenPhrase;
+    }
+
+    @Override
+    public boolean test(Flashcard flashcard) {
+        return flashcard.getEnglishPhrase().value.equalsIgnoreCase(givenPhrase.value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof EnglishPhraseMatchesGivenPhrasePredicate
+                && givenPhrase.equals(((EnglishPhraseMatchesGivenPhrasePredicate) other).givenPhrase));
+    }
+}

--- a/src/main/java/lingogo/model/flashcard/Flashcard.java
+++ b/src/main/java/lingogo/model/flashcard/Flashcard.java
@@ -72,7 +72,7 @@ public class Flashcard {
         builder.append("English phrase: ")
                 .append(getEnglishPhrase())
                 .append("\n")
-                .append("Answer: ")
+                .append("Foreign Phrase: ")
                 .append(getForeignPhrase());
         return builder.toString();
     }

--- a/src/main/java/lingogo/ui/CommandHelpMessage.java
+++ b/src/main/java/lingogo/ui/CommandHelpMessage.java
@@ -12,6 +12,7 @@ import lingogo.logic.commands.ExitCommand;
 import lingogo.logic.commands.FindCommand;
 import lingogo.logic.commands.HelpCommand;
 import lingogo.logic.commands.ListCommand;
+import lingogo.logic.commands.TestCommand;
 
 public class CommandHelpMessage extends UiPart<TitledPane> {
     private static final String FXML = "CommandHelpMessage.fxml";
@@ -21,10 +22,7 @@ public class CommandHelpMessage extends UiPart<TitledPane> {
             + " phrase";
     private static final String FLIP_COMMAND_USAGE = "flip INDEX";
     private static final String FLIP_COMMAND_EXAMPLES = "flip 3";
-    private static final String TEST_COMMAND_DESCRIPTION = "Checks whether the English phrase of a flashcard"
-            + " matches a given phrase";
-    private static final String TEST_COMMAND_USAGE = "test INDEX a/ENGLISH_PHRASE";
-    private static final String TEST_COMMAND_EXAMPLES = "test 1 a/good morning";
+
     private static final String IMPORT_COMMAND_DESCRIPTION = "Imports flashcards into LingoGO! from a specified"
             + " CSV file";
     private static final String IMPORT_COMMAND_USAGE = "upload CSV_FILE_PATH";
@@ -93,8 +91,8 @@ public class CommandHelpMessage extends UiPart<TitledPane> {
                     ListCommand.COMMAND_EXAMPLES);
             break;
         case TEST:
-            this.setDisplayText("test", TEST_COMMAND_DESCRIPTION, TEST_COMMAND_USAGE,
-                    TEST_COMMAND_EXAMPLES);
+            this.setDisplayText(TestCommand.COMMAND_WORD, TestCommand.COMMAND_DESCRIPTION, TestCommand.COMMAND_USAGE,
+                    TestCommand.COMMAND_EXAMPLES);
             break;
         case EXPORT:
             this.setDisplayText("download", EXPORT_COMMAND_DESCRIPTION, EXPORT_COMMAND_USAGE,

--- a/src/test/java/lingogo/logic/commands/CommandTestUtil.java
+++ b/src/test/java/lingogo/logic/commands/CommandTestUtil.java
@@ -27,6 +27,8 @@ public class CommandTestUtil {
     public static final String VALID_CHINESE_PHRASE_HELLO = "你好";
     public static final String VALID_ENGLISH_PHRASE_GOOD_MORNING = "Good Morning";
     public static final String VALID_CHINESE_PHRASE_GOOD_MORNING = "早安";
+    public static final String VALID_ENGLISH_PHRASE_AFTERNOON = "Afternoon";
+
 
     public static final String CHINESE_PHRASE_DESC_GOOD_MORNING = " " + PREFIX_FOREIGN_PHRASE
             + VALID_CHINESE_PHRASE_GOOD_MORNING;

--- a/src/test/java/lingogo/logic/commands/CommandTestUtil.java
+++ b/src/test/java/lingogo/logic/commands/CommandTestUtil.java
@@ -29,7 +29,6 @@ public class CommandTestUtil {
     public static final String VALID_CHINESE_PHRASE_GOOD_MORNING = "早安";
     public static final String VALID_ENGLISH_PHRASE_AFTERNOON = "Afternoon";
 
-
     public static final String CHINESE_PHRASE_DESC_GOOD_MORNING = " " + PREFIX_FOREIGN_PHRASE
             + VALID_CHINESE_PHRASE_GOOD_MORNING;
     public static final String CHINESE_PHRASE_DESC_HELLO = " " + PREFIX_FOREIGN_PHRASE

--- a/src/test/java/lingogo/logic/commands/TestCommandTest.java
+++ b/src/test/java/lingogo/logic/commands/TestCommandTest.java
@@ -36,7 +36,7 @@ public class TestCommandTest {
         Flashcard flashcardToTest = model.getFilteredFlashcardList().get(INDEX_FIRST_FLASHCARD.getZeroBased());
         TestCommand testCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseAfternoon);
 
-        String expectedMessage = String.format(testCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
+        String expectedMessage = String.format(TestCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
             flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
 
         ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
@@ -49,7 +49,7 @@ public class TestCommandTest {
         Flashcard flashcardToTest = model.getFilteredFlashcardList().get(INDEX_FIRST_FLASHCARD.getZeroBased());
         TestCommand testCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseGoodMorning);
 
-        String expectedMessage = String.format(testCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG,
+        String expectedMessage = String.format(TestCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG,
             flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_GOOD_MORNING);
 
         ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());

--- a/src/test/java/lingogo/logic/commands/TestCommandTest.java
+++ b/src/test/java/lingogo/logic/commands/TestCommandTest.java
@@ -1,0 +1,138 @@
+package lingogo.logic.commands;
+
+import static lingogo.logic.commands.CommandTestUtil.VALID_ENGLISH_PHRASE_AFTERNOON;
+import static lingogo.logic.commands.CommandTestUtil.VALID_ENGLISH_PHRASE_GOOD_MORNING;
+import static lingogo.logic.commands.CommandTestUtil.assertCommandFailure;
+import static lingogo.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static lingogo.logic.commands.CommandTestUtil.showFlashcardAtIndex;
+import static lingogo.testutil.TypicalFlashcards.getTypicalFlashcardApp;
+import static lingogo.testutil.TypicalIndexes.INDEX_FIRST_FLASHCARD;
+import static lingogo.testutil.TypicalIndexes.INDEX_SECOND_FLASHCARD;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import lingogo.commons.core.Messages;
+import lingogo.commons.core.index.Index;
+import lingogo.model.Model;
+import lingogo.model.ModelManager;
+import lingogo.model.UserPrefs;
+import lingogo.model.flashcard.Flashcard;
+import lingogo.model.flashcard.Phrase;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code TestCommand}.
+ */
+public class TestCommandTest {
+
+    private Model model = new ModelManager(getTypicalFlashcardApp(), new UserPrefs());
+    private Phrase validPhraseAfternoon = new Phrase(VALID_ENGLISH_PHRASE_AFTERNOON);
+    private Phrase validPhraseGoodMorning = new Phrase(VALID_ENGLISH_PHRASE_GOOD_MORNING);
+
+    @Test
+    public void execute_validIndexUnfilteredListCorrectGivenPhrase_success() {
+        Flashcard flashcardToTest = model.getFilteredFlashcardList().get(INDEX_FIRST_FLASHCARD.getZeroBased());
+        TestCommand testCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseAfternoon);
+
+        String expectedMessage = String.format(testCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
+            flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
+
+        ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
+
+        assertCommandSuccess(testCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredListWrongGivenPhrase_success() {
+        Flashcard flashcardToTest = model.getFilteredFlashcardList().get(INDEX_FIRST_FLASHCARD.getZeroBased());
+        TestCommand testCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseGoodMorning);
+
+        String expectedMessage = String.format(testCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG,
+            flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_GOOD_MORNING);
+
+        ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
+
+        assertCommandSuccess(testCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredFlashcardList().size() + 1);
+        TestCommand testCommand = new TestCommand(outOfBoundIndex, validPhraseAfternoon);
+
+        assertCommandFailure(testCommand, model, Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredListCorrectGivenPhrase_success() {
+        showFlashcardAtIndex(model, INDEX_FIRST_FLASHCARD);
+
+        Flashcard flashcardToTest = model.getFilteredFlashcardList().get(INDEX_FIRST_FLASHCARD.getZeroBased());
+        TestCommand testCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseAfternoon);
+
+        String expectedMessage =
+            String.format(TestCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT, flashcardToTest.getForeignPhrase(),
+                flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
+
+        Model expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
+        showFlashcardAtIndex(expectedModel, INDEX_FIRST_FLASHCARD);
+
+
+        assertCommandSuccess(testCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredListWrongGivenPhrase_success() {
+        showFlashcardAtIndex(model, INDEX_SECOND_FLASHCARD);
+
+        Flashcard flashcardToTest = model.getFilteredFlashcardList().get(INDEX_FIRST_FLASHCARD.getZeroBased());
+        TestCommand testCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseAfternoon);
+
+        String expectedMessage =
+            String.format(TestCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG, flashcardToTest.getForeignPhrase(),
+                flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
+
+        Model expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
+        showFlashcardAtIndex(expectedModel, INDEX_SECOND_FLASHCARD);
+
+
+        assertCommandSuccess(testCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showFlashcardAtIndex(model, INDEX_FIRST_FLASHCARD);
+
+        Index outOfBoundIndex = INDEX_SECOND_FLASHCARD;
+        // ensures that outOfBoundIndex is still in bounds of flashcard app list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getFlashcardApp().getFlashcardList().size());
+
+        TestCommand testCommand = new TestCommand(outOfBoundIndex, validPhraseAfternoon);
+
+        assertCommandFailure(testCommand, model, Messages.MESSAGE_INVALID_FLASHCARD_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        TestCommand testFirstCommand = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseAfternoon);
+        TestCommand testSecondCommand = new TestCommand(INDEX_SECOND_FLASHCARD, validPhraseAfternoon);
+
+        // same object -> returns true
+        assertTrue(testFirstCommand.equals(testFirstCommand));
+
+        // same values -> returns true
+        TestCommand testFirstCommandCopy = new TestCommand(INDEX_FIRST_FLASHCARD, validPhraseAfternoon);
+        assertTrue(testFirstCommand.equals(testFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(testFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(testFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(testFirstCommand.equals(testSecondCommand));
+    }
+}

--- a/src/test/java/lingogo/logic/parser/FlashcardAppParserTest.java
+++ b/src/test/java/lingogo/logic/parser/FlashcardAppParserTest.java
@@ -2,6 +2,7 @@ package lingogo.logic.parser;
 
 import static lingogo.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static lingogo.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static lingogo.logic.commands.CommandTestUtil.VALID_ENGLISH_PHRASE_GOOD_MORNING;
 import static lingogo.testutil.Assert.assertThrows;
 import static lingogo.testutil.TypicalIndexes.INDEX_FIRST_FLASHCARD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,12 +23,14 @@ import lingogo.logic.commands.ExitCommand;
 import lingogo.logic.commands.FindCommand;
 import lingogo.logic.commands.HelpCommand;
 import lingogo.logic.commands.ListCommand;
+import lingogo.logic.commands.TestCommand;
 import lingogo.logic.parser.exceptions.ParseException;
 import lingogo.model.flashcard.EnglishPhraseContainsKeywordsPredicate;
 import lingogo.model.flashcard.Flashcard;
 import lingogo.testutil.EditFlashcardDescriptorBuilder;
 import lingogo.testutil.FlashcardBuilder;
 import lingogo.testutil.FlashcardUtil;
+
 
 public class FlashcardAppParserTest {
 
@@ -49,7 +52,7 @@ public class FlashcardAppParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_FLASHCARD.getOneBased());
+            DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_FLASHCARD.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_FLASHCARD), command);
     }
 
@@ -58,8 +61,8 @@ public class FlashcardAppParserTest {
         Flashcard flashcard = new FlashcardBuilder().build();
         EditFlashcardDescriptor descriptor = new EditFlashcardDescriptorBuilder(flashcard).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_FLASHCARD.getOneBased() + " "
-                + FlashcardUtil.getEditFlashcardDescriptorDetails(descriptor));
+            + INDEX_FIRST_FLASHCARD.getOneBased() + " "
+            + FlashcardUtil.getEditFlashcardDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_FLASHCARD, descriptor), command);
     }
 
@@ -73,7 +76,7 @@ public class FlashcardAppParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+            FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new EnglishPhraseContainsKeywordsPredicate(keywords)), command);
     }
 
@@ -87,6 +90,13 @@ public class FlashcardAppParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_test() throws Exception {
+        assertEquals(new TestCommand(INDEX_FIRST_FLASHCARD, ParserUtil.parsePhrase(VALID_ENGLISH_PHRASE_GOOD_MORNING)),
+            parser.parseCommand(TestCommand.COMMAND_WORD + " " + INDEX_FIRST_FLASHCARD.getOneBased() + " e/"
+                + VALID_ENGLISH_PHRASE_GOOD_MORNING));
     }
 
     @Test

--- a/src/test/java/lingogo/logic/parser/FlashcardAppParserTest.java
+++ b/src/test/java/lingogo/logic/parser/FlashcardAppParserTest.java
@@ -3,6 +3,7 @@ package lingogo.logic.parser;
 import static lingogo.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static lingogo.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static lingogo.logic.commands.CommandTestUtil.VALID_ENGLISH_PHRASE_GOOD_MORNING;
+import static lingogo.logic.parser.CliSyntax.PREFIX_ENGLISH_PHRASE;
 import static lingogo.testutil.Assert.assertThrows;
 import static lingogo.testutil.TypicalIndexes.INDEX_FIRST_FLASHCARD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -94,9 +95,11 @@ public class FlashcardAppParserTest {
 
     @Test
     public void parseCommand_test() throws Exception {
+        TestCommand command = (TestCommand) parser.parseCommand(
+            TestCommand.COMMAND_WORD + " " + INDEX_FIRST_FLASHCARD.getOneBased() + " " + PREFIX_ENGLISH_PHRASE
+            + VALID_ENGLISH_PHRASE_GOOD_MORNING);
         assertEquals(new TestCommand(INDEX_FIRST_FLASHCARD, ParserUtil.parsePhrase(VALID_ENGLISH_PHRASE_GOOD_MORNING)),
-            parser.parseCommand(TestCommand.COMMAND_WORD + " " + INDEX_FIRST_FLASHCARD.getOneBased() + " e/"
-                + VALID_ENGLISH_PHRASE_GOOD_MORNING));
+            command);
     }
 
     @Test

--- a/src/test/java/lingogo/logic/parser/TestCommandParserTest.java
+++ b/src/test/java/lingogo/logic/parser/TestCommandParserTest.java
@@ -1,0 +1,69 @@
+package lingogo.logic.parser;
+
+import static lingogo.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static lingogo.logic.commands.CommandTestUtil.ENGLISH_PHRASE_DESC_GOOD_MORNING;
+import static lingogo.logic.commands.CommandTestUtil.INVALID_ENGLISH_PHRASE_DESC;
+import static lingogo.logic.commands.CommandTestUtil.VALID_ENGLISH_PHRASE_GOOD_MORNING;
+import static lingogo.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static lingogo.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static lingogo.testutil.TypicalIndexes.INDEX_SECOND_FLASHCARD;
+
+import org.junit.jupiter.api.Test;
+
+import lingogo.commons.core.index.Index;
+import lingogo.logic.commands.TestCommand;
+import lingogo.model.flashcard.Phrase;
+
+public class TestCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+        String.format(MESSAGE_INVALID_COMMAND_FORMAT, TestCommand.MESSAGE_USAGE);
+
+    private TestCommandParser parser = new TestCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, ENGLISH_PHRASE_DESC_GOOD_MORNING, MESSAGE_INVALID_FORMAT);
+
+        // no English phrase specified
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+
+        // no index and no phrase specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // no prefix for English phrase specified
+        assertParseFailure(parser, "1 " + VALID_ENGLISH_PHRASE_GOOD_MORNING, MESSAGE_INVALID_FORMAT);
+
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + ENGLISH_PHRASE_DESC_GOOD_MORNING, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + ENGLISH_PHRASE_DESC_GOOD_MORNING, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_ENGLISH_PHRASE_DESC,
+            Phrase.MESSAGE_CONSTRAINTS); // invalid English phrase
+    }
+
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_FLASHCARD;
+        String userInput = targetIndex.getOneBased() + ENGLISH_PHRASE_DESC_GOOD_MORNING;
+        TestCommand expectedCommand = new TestCommand(targetIndex, new Phrase(VALID_ENGLISH_PHRASE_GOOD_MORNING));
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}


### PR DESCRIPTION
### Description

Added the test flashcard feature for V1.2. Note that at this point user guide still contradicts implementation as you can still test a flashcard that has been "flipped up" (i.e you can still test a flashcard even when you can clearly see its English Phrase).  

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements

### How to test

Manual testing:
1. Create a flashcard (e.g. “add e/hello donkey f/你好驴子”)
2. Use the test command by typing "test INDEX e/ENGLISH_PHRASE" (e.g. "test 1 e/hello donkey")
3. If the given English phrase matches that of the flashcard of the specified index, output should be "Well Done! You got it right! ..." 
4. Else, output should be "Oh no! You got it wrong! ..."
5. Note: Match is case-insensitive ("hello donkey" matches with "HELLO doNkeY")


Updated user guide at https://tp-g6sl6ukhw-aikenwx.vercel.app/UserGuide.html


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have written testcases to cover all new methods
- [x] I have built and manually tested this code
- [x] I have updated the User Guide

