### PR TITLE
Fix empty slideshow starting bug

### DIFF
--- a/src/main/java/lingogo/logic/commands/SlideshowCommand.java
+++ b/src/main/java/lingogo/logic/commands/SlideshowCommand.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import lingogo.commons.core.Messages;
 import lingogo.logic.commands.exceptions.CommandException;
 import lingogo.model.Model;
+import lingogo.model.slideshow.exceptions.EmptySlideshowException;
 
 public class SlideshowCommand extends Command {
 
@@ -14,6 +15,7 @@ public class SlideshowCommand extends Command {
     public static final String COMMAND_USAGE = "slideshow";
     public static final String COMMAND_EXAMPLES = "slideshow";
     public static final String MESSAGE_SUCCESS = "Slideshow started!";
+    public static final String MESSAGE_EMPTY_SLIDESHOW = "An empty slideshow cannot be started!";
 
 
     @Override
@@ -24,7 +26,12 @@ public class SlideshowCommand extends Command {
             throw new CommandException(Messages.MESSAGE_IN_SLIDESHOW_MODE);
         }
 
-        model.startSlideshow();
+        try {
+            model.startSlideshow();
+        } catch (EmptySlideshowException e) {
+            throw new CommandException(MESSAGE_EMPTY_SLIDESHOW);
+        }
+
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/test/java/lingogo/logic/commands/SlideshowCommandTest.java
+++ b/src/test/java/lingogo/logic/commands/SlideshowCommandTest.java
@@ -2,6 +2,7 @@ package lingogo.logic.commands;
 
 import static lingogo.logic.commands.CommandTestUtil.assertCommandFailure;
 import static lingogo.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static lingogo.logic.commands.SlideshowCommand.MESSAGE_EMPTY_SLIDESHOW;
 import static lingogo.testutil.TypicalFlashcards.getTypicalFlashcardApp;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,6 +37,13 @@ public class SlideshowCommandTest {
         model.startSlideshow();
 
         assertCommandFailure(new SlideshowCommand(), model, Messages.MESSAGE_IN_SLIDESHOW_MODE);
+    }
+
+    @Test
+    public void execute_emptySlideshow_throwsCommandException() {
+        model = new ModelManager();
+
+        assertCommandFailure(new SlideshowCommand(), model, MESSAGE_EMPTY_SLIDESHOW);
     }
 
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
Previously, the runtime error was not caught and reflected in the UI

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
Clear your flashcards and start the slideshow

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have written testcases to cover all new methods
- [x] I have built and manually tested this code
