### PR TITLE
Gui text overflow

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -214,6 +214,14 @@ Format: `edit INDEX [l/LANGUAGE] [e/ENGLISH_PHRASE] [f/FOREIGN_PHRASE]`
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
 * **At least one** of the optional fields must be provided.
 
+<div markdown="block" class="alert alert-info">
+
+**:information_source: Notes about editing flashcards:**<br>
+
+* `ENGLISH_PHRASE` and `FOREIGN_PHRASE` should not be longer than 50 characters.
+
+</div>
+
 Examples:
 * `edit 1 l/German` Edits the language of the 1st flashcard to be `German`.
 * `edit 1 e/Good Morning` Edits the English phrase of the 1st flashcard to be `Good Morning`.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,6 +120,14 @@ In slideshow mode, you can:
   [`previous`](#moving-to-the-previous-flashcard-in-slideshow-mode--previous) flashcards
 * Enter an [`answer`](#answering-a-flashcard--answer) for a flashcard
 
+<div markdown="block" class="alert alert-info">
+
+**:information_source: Notes about slideshow mode:**<br>
+
+* If your flashcards have phrases that are too long to be displayed, you can **increase the app's window size**.
+
+</div>
+
 ## Commands
 
 The following section gives an indepth overview of each command in the application, and provides some examples on their usages.
@@ -158,7 +166,9 @@ Format: `add l/LANGUAGE e/ENGLISH_PHRASE f/FOREIGN_PHRASE`
 
 **:information_source: Notes about adding flashcards:**<br>
 
-* `ENGLISH_PHRASE` and `FOREIGN_PHRASE` should not be longer than 50 characters.
+* `ENGLISH_PHRASE` and `FOREIGN_PHRASE` should not be longer than **100 characters**.
+  For optimal viewing experience, flashcard phrases should be kept as short as possible.
+  If your phrases are too long to be displayed, you can **increase the app's window size**.
 
 </div>
 
@@ -218,7 +228,9 @@ Format: `edit INDEX [l/LANGUAGE] [e/ENGLISH_PHRASE] [f/FOREIGN_PHRASE]`
 
 **:information_source: Notes about editing flashcards:**<br>
 
-* `ENGLISH_PHRASE` and `FOREIGN_PHRASE` should not be longer than 50 characters.
+* `ENGLISH_PHRASE` and `FOREIGN_PHRASE` should not be longer than **100 characters**.
+  For optimal viewing experience, flashcard phrases should be kept as short as possible.
+  If your phrases are too long to be displayed, you can **increase the app's window size**.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -154,6 +154,14 @@ Adds a flashcard to LingoGO!.
 
 Format: `add l/LANGUAGE e/ENGLISH_PHRASE f/FOREIGN_PHRASE`
 
+<div markdown="block" class="alert alert-info">
+
+**:information_source: Notes about adding flashcards:**<br>
+
+* `ENGLISH_PHRASE` and `FOREIGN_PHRASE` should not be longer than 50 characters.
+
+</div>
+
 Examples:
 * `add l/Chinese e/Good Morning f/早安`
 

--- a/src/main/java/lingogo/commons/core/GuiSettings.java
+++ b/src/main/java/lingogo/commons/core/GuiSettings.java
@@ -10,8 +10,8 @@ import java.util.Objects;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_HEIGHT = 680;
+    private static final double DEFAULT_WIDTH = 1000;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/java/lingogo/model/flashcard/Phrase.java
+++ b/src/main/java/lingogo/model/flashcard/Phrase.java
@@ -8,16 +8,16 @@ import static lingogo.commons.util.AppUtil.checkArgument;
  * Guarantees: immutable; is valid as declared in {@link #isValidPhrase(String)}
  */
 public class Phrase {
-    public static final String MESSAGE_CONSTRAINTS = "Phrases can take Unicode alphabet characters,"
-        + " should not be blank, and must be no longer than 50 characters.";
-
     /**
      * {@code \\S} The first character of the phrase must not be a whitespace.
      * This prevents " " (a blank string) from becoming a valid input.
      * {@code \\[^\n]*} Allows us to match any character that is not a new line character 0 or more times.
      */
     public static final String VALIDATION_REGEX = "\\S[^\n]*";
-    public static final int MAX_NUMBER_OF_CHARACTERS = 50;
+    public static final int MAX_NUMBER_OF_CHARACTERS = 100;
+
+    public static final String MESSAGE_CONSTRAINTS = "Phrases can take Unicode alphabet characters,"
+            + " should not be blank, and must be no longer than " + MAX_NUMBER_OF_CHARACTERS + " characters.";
 
     public final String value;
 

--- a/src/main/java/lingogo/model/flashcard/Phrase.java
+++ b/src/main/java/lingogo/model/flashcard/Phrase.java
@@ -9,7 +9,7 @@ import static lingogo.commons.util.AppUtil.checkArgument;
  */
 public class Phrase {
     public static final String MESSAGE_CONSTRAINTS = "Phrases can take Unicode alphabet characters,"
-        + " and should not be blank";
+        + " should not be blank, and must be no longer than 50 characters.";
 
     /**
      * {@code \\S} The first character of the phrase must not be a whitespace.
@@ -17,6 +17,7 @@ public class Phrase {
      * {@code \\[^\n]*} Allows us to match any character that is not a new line character 0 or more times.
      */
     public static final String VALIDATION_REGEX = "\\S[^\n]*";
+    public static final int MAX_NUMBER_OF_CHARACTERS = 50;
 
     public final String value;
 
@@ -35,7 +36,7 @@ public class Phrase {
      * Returns true if a given phrase is a valid phrase.
      */
     public static boolean isValidPhrase(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_NUMBER_OF_CHARACTERS;
     }
 
     @Override

--- a/src/main/java/lingogo/ui/FlashcardPane.java
+++ b/src/main/java/lingogo/ui/FlashcardPane.java
@@ -2,8 +2,9 @@ package lingogo.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.HBox;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
+import javafx.scene.text.Text;
 import lingogo.model.flashcard.Flashcard;
 
 /**
@@ -24,15 +25,15 @@ public class FlashcardPane extends UiPart<Region> {
     public final Flashcard flashcard;
 
     @FXML
-    private HBox cardPane;
+    private GridPane cardPane;
     @FXML
     private Label id;
     @FXML
     private Label language;
     @FXML
-    private Label foreignPhrase;
+    private Text foreignPhrase;
     @FXML
-    private Label englishPhrase;
+    private Text englishPhrase;
 
     /**
      * Creates a {@code FlashcardPane} with the given {@code Flashcard} and index to display.
@@ -44,6 +45,17 @@ public class FlashcardPane extends UiPart<Region> {
         language.setText(flashcard.getLanguageType().value);
         foreignPhrase.setText(flashcard.getForeignPhrase().value);
         englishPhrase.setText(flashcard.getEnglishPhrase().value);
+
+        foreignPhrase.setWrappingWidth(cardPane.getColumnConstraints().get(2).getPrefWidth());
+        englishPhrase.setWrappingWidth(cardPane.getColumnConstraints().get(3).getPrefWidth());
+
+        double heightNeeded =
+                Math.max(foreignPhrase.getLayoutBounds().getHeight(), englishPhrase.getLayoutBounds().getHeight());
+        cardPane.setMinHeight(
+                Math.max(foreignPhrase.getLayoutBounds().getHeight(), englishPhrase.getLayoutBounds().getHeight()));
+        if (cardPane.getPrefHeight() < heightNeeded) {
+            cardPane.setPrefHeight(heightNeeded);
+        }
     }
 
     @Override

--- a/src/main/java/lingogo/ui/SlideshowPanel.java
+++ b/src/main/java/lingogo/ui/SlideshowPanel.java
@@ -17,7 +17,7 @@ import lingogo.model.flashcard.Flashcard;
 public class SlideshowPanel extends UiPart<Region> {
     private static final String FXML = "SlideshowPanel.fxml";
     private static final String CURRENT_FLASHCARD_NUMBER_FORMAT_STRING = "Current flashcard: %s";
-    private static final String ANSWER_FORMAT_STRING = "Answer: %s";
+    private static final String ANSWER_HEADER_STRING = "Answer:";
     private static final String PROGRESS_FORMAT_STRING = "Flashcards answered: %s";
 
     private final Logger logger = LogsCenter.getLogger(FlashcardListPanel.class);
@@ -26,6 +26,8 @@ public class SlideshowPanel extends UiPart<Region> {
     private Label currentFlashcardNumber;
     @FXML
     private Label currentForeignPhrase;
+    @FXML
+    private Label answerHeader;
     @FXML
     private Label answer;
     @FXML
@@ -43,8 +45,10 @@ public class SlideshowPanel extends UiPart<Region> {
                         readOnlySlideshowApp.getCurrentSlideNumber()));
                 currentForeignPhrase.setText(newVal.getForeignPhrase().toString());
                 if (readOnlySlideshowApp.isCurrentSlideAnswered()) {
-                    answer.setText(String.format(ANSWER_FORMAT_STRING, newVal.getEnglishPhrase().toString()));
+                    answerHeader.setText(ANSWER_HEADER_STRING);
+                    answer.setText(newVal.getEnglishPhrase().toString());
                 } else {
+                    answerHeader.setText("");
                     answer.setText("");
                 }
                 progress.setText(String.format(PROGRESS_FORMAT_STRING, readOnlySlideshowApp.getProgress()));
@@ -54,10 +58,11 @@ public class SlideshowPanel extends UiPart<Region> {
             @Override
             public void changed(ObservableValue<? extends Boolean> o, Boolean oldVal, Boolean newVal) {
                 if (newVal) {
-                    answer.setText(String.format(ANSWER_FORMAT_STRING,
-                            readOnlySlideshowApp.getCurrentSlide().getEnglishPhrase().toString()));
+                    answerHeader.setText(ANSWER_HEADER_STRING);
+                    answer.setText(readOnlySlideshowApp.getCurrentSlide().getEnglishPhrase().toString());
                     progress.setText(String.format(PROGRESS_FORMAT_STRING, readOnlySlideshowApp.getProgress()));
                 } else {
+                    answerHeader.setText("");
                     answer.setText("");
                 }
             }

--- a/src/main/resources/view/FlashcardPane.fxml
+++ b/src/main/resources/view/FlashcardPane.fxml
@@ -23,21 +23,22 @@
         <Insets left="5.0" right="5.0" />
       </padding>
     </Label>
-    <Label fx:id="language" text="Language" GridPane.columnIndex="1" style="-fx-font-family: 'Open Sans'">
+    <Label fx:id="language" text="Language" GridPane.columnIndex="1" wrapText="true"
+           style="-fx-font-family: 'Open Sans'" textAlignment="CENTER">
       <padding>
         <Insets left="5.0" right="5.0" />
       </padding>
     </Label>
     <Label fx:id="foreignPhrase" text="Foreign Phrase" GridPane.columnIndex="2" wrapText="true"
-           style="-fx-font-family: 'Open Sans'">
+           style="-fx-font-family: 'Open Sans'" textAlignment="CENTER">
       <padding>
-        <Insets left="5.0" right="5.0" />
+        <Insets left="10.0" right="10.0" />
       </padding>
     </Label>
     <Label fx:id="englishPhrase" text="English Phrase" GridPane.columnIndex="3" wrapText="true"
-           style="-fx-font-family: 'Open Sans'">
+           style="-fx-font-family: 'Open Sans'" textAlignment="CENTER">
       <padding>
-        <Insets left="5.0" right="5.0" />
+        <Insets left="10.0" right="10.0" />
       </padding>
     </Label>
   </GridPane>

--- a/src/main/resources/view/FlashcardPane.fxml
+++ b/src/main/resources/view/FlashcardPane.fxml
@@ -6,17 +6,18 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.text.Text?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <GridPane id="cardGridPane" HBox.hgrow="ALWAYS" prefHeight="60" alignment="CENTER">
+<HBox id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <GridPane fx:id="cardPane" id="cardGridPane" HBox.hgrow="ALWAYS" prefHeight="60" maxHeight="Infinity" minHeight="60" alignment="CENTER">
     <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="50" percentWidth="10" halignment="CENTER" />
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="50" percentWidth="20" halignment="CENTER" />
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="50" percentWidth="35" halignment="CENTER" />
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="50" percentWidth="35" halignment="CENTER" />
+      <ColumnConstraints hgrow="SOMETIMES" prefWidth="50" percentWidth="10" halignment="CENTER" />
+      <ColumnConstraints hgrow="SOMETIMES" prefWidth="50" percentWidth="20" halignment="CENTER" />
+      <ColumnConstraints hgrow="SOMETIMES" prefWidth="180" percentWidth="35" halignment="CENTER" />
+      <ColumnConstraints hgrow="SOMETIMES" prefWidth="180" percentWidth="35" halignment="CENTER" />
     </columnConstraints>
     <rowConstraints>
-      <RowConstraints vgrow="SOMETIMES" prefHeight="60" />
+      <RowConstraints vgrow="ALWAYS" prefHeight="60" maxHeight="Infinity" minHeight="60" />
     </rowConstraints>
     <Label fx:id="id" text="ID" GridPane.columnIndex="0" style="-fx-font-family: 'Open Sans'">
       <padding>
@@ -29,17 +30,11 @@
         <Insets left="5.0" right="5.0" />
       </padding>
     </Label>
-    <Label fx:id="foreignPhrase" text="Foreign Phrase" GridPane.columnIndex="2" wrapText="true"
+    <Text fx:id="foreignPhrase" text="Foreign Phrase" GridPane.columnIndex="2"
            style="-fx-font-family: 'Open Sans'" textAlignment="CENTER">
-      <padding>
-        <Insets left="10.0" right="10.0" />
-      </padding>
-    </Label>
-    <Label fx:id="englishPhrase" text="English Phrase" GridPane.columnIndex="3" wrapText="true"
+    </Text>
+    <Text fx:id="englishPhrase" text="English Phrase" GridPane.columnIndex="3"
            style="-fx-font-family: 'Open Sans'" textAlignment="CENTER">
-      <padding>
-        <Insets left="10.0" right="10.0" />
-      </padding>
-    </Label>
+    </Text>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -18,7 +18,7 @@
 }
 
 .label-header {
-    -fx-font-size: 32pt;
+    -fx-font-size: 26pt;
     -fx-font-family: "Open Sans Light";
     -fx-text-fill: #303545;
     -fx-opacity: 1;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="600" onCloseRequest="#handleExit" title="LingoGO!" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="740" onCloseRequest="#handleExit" title="LingoGO!" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/lingogo_logo.png" />
   </icons>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>

--- a/src/main/resources/view/SlideshowPanel.fxml
+++ b/src/main/resources/view/SlideshowPanel.fxml
@@ -13,9 +13,17 @@
     <Label styleClass="label-bright" fx:id="currentFlashcardNumber" text="Flashcard number: 1" />
   </StackPane>
   <VBox alignment="CENTER" VBox.vgrow="ALWAYS">
+    <padding>
+      <Insets top="10" right="50" bottom="10" left="50" />
+    </padding>
     <Label styleClass="label-bright" text="What does this mean?" />
     <Label styleClass="label-header" fx:id="currentForeignPhrase"
-           text="Foreign Phrase" wrapText="true" textAlignment="CENTER" />
+           text="Foreign Phrase" wrapText="true" textAlignment="CENTER">
+      <padding>
+        <Insets bottom="10" />
+      </padding>
+    </Label>
+    <Label styleClass="label-bright" fx:id="answerHeader" text="Answer:" />
     <Label styleClass="label-header" fx:id="answer"
            text="" wrapText="true" textAlignment="CENTER" />
   </VBox>

--- a/src/test/java/lingogo/logic/commands/CommandTestUtil.java
+++ b/src/test/java/lingogo/logic/commands/CommandTestUtil.java
@@ -71,6 +71,15 @@ public class CommandTestUtil {
             + "    "; // Phrases cannot be empty
     public static final String INVALID_ENGLISH_PHRASE_DESC = " " + PREFIX_ENGLISH_PHRASE
             + "    "; // Phrases cannot be empty
+    public static final String INVALID_LONG_ENGLISH_PHRASE_DESC = " " + PREFIX_ENGLISH_PHRASE
+            + "This invalid string is about 51 characters long :(.";
+    public static final String INVALID_LONG_FOREIGN_PHRASE_DESC = " " + PREFIX_FOREIGN_PHRASE
+            + "哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈哈";
+
     public static final String INVALID_NEGATIVE_INDEX_DESC = " " + PREFIX_INDEX_LIST + "-1";
 
     public static final String INVALID_INDICES_DESC = " " + PREFIX_INDEX_LIST + "1 1 C ; , ?";

--- a/src/test/java/lingogo/logic/commands/CommandTestUtil.java
+++ b/src/test/java/lingogo/logic/commands/CommandTestUtil.java
@@ -72,13 +72,17 @@ public class CommandTestUtil {
     public static final String INVALID_ENGLISH_PHRASE_DESC = " " + PREFIX_ENGLISH_PHRASE
             + "    "; // Phrases cannot be empty
     public static final String INVALID_LONG_ENGLISH_PHRASE_DESC = " " + PREFIX_ENGLISH_PHRASE
-            + "This invalid string is about 51 characters long :(.";
+            + "aaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaa"
+            + "aaaaaaaaaaaaaaaaaaaaa"; // 101 character English phrase
     public static final String INVALID_LONG_FOREIGN_PHRASE_DESC = " " + PREFIX_FOREIGN_PHRASE
-            + "哈哈哈哈哈哈哈哈哈哈"
-            + "哈哈哈哈哈哈哈哈哈哈"
-            + "哈哈哈哈哈哈哈哈哈哈"
-            + "哈哈哈哈哈哈哈哈哈哈"
-            + "哈哈哈哈哈哈哈哈哈哈哈";
+            + "哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈"
+            + "哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈哈"; // 101 character foreign phrase
 
     public static final String INVALID_NEGATIVE_INDEX_DESC = " " + PREFIX_INDEX_LIST + "-1";
 

--- a/src/test/java/lingogo/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/lingogo/logic/parser/AddCommandParserTest.java
@@ -9,6 +9,8 @@ import static lingogo.logic.commands.CommandTestUtil.ENGLISH_PHRASE_DESC_SUNRISE
 import static lingogo.logic.commands.CommandTestUtil.INVALID_ENGLISH_PHRASE_DESC;
 import static lingogo.logic.commands.CommandTestUtil.INVALID_FOREIGN_PHRASE_DESC;
 import static lingogo.logic.commands.CommandTestUtil.INVALID_LANGUAGE_TYPE_DESC;
+import static lingogo.logic.commands.CommandTestUtil.INVALID_LONG_ENGLISH_PHRASE_DESC;
+import static lingogo.logic.commands.CommandTestUtil.INVALID_LONG_FOREIGN_PHRASE_DESC;
 import static lingogo.logic.commands.CommandTestUtil.LANGUAGE_TYPE_DESC_CHINESE;
 import static lingogo.logic.commands.CommandTestUtil.LANGUAGE_TYPE_DESC_TAMIL;
 import static lingogo.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
@@ -95,6 +97,14 @@ public class AddCommandParserTest {
         // invalid foreign phrase
         assertParseFailure(parser, LANGUAGE_TYPE_DESC_CHINESE
                 + ENGLISH_PHRASE_DESC_HELLO + INVALID_FOREIGN_PHRASE_DESC, Phrase.MESSAGE_CONSTRAINTS);
+
+        // English phrase too long
+        assertParseFailure(parser, LANGUAGE_TYPE_DESC_CHINESE
+                + INVALID_LONG_ENGLISH_PHRASE_DESC + CHINESE_PHRASE_DESC_HELLO, Phrase.MESSAGE_CONSTRAINTS);
+
+        //Foreign phrase too long
+        assertParseFailure(parser, LANGUAGE_TYPE_DESC_CHINESE
+                + ENGLISH_PHRASE_DESC_HELLO + INVALID_LONG_FOREIGN_PHRASE_DESC, Phrase.MESSAGE_CONSTRAINTS);
 
         // three invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_LANGUAGE_TYPE_DESC + INVALID_ENGLISH_PHRASE_DESC

--- a/src/test/java/lingogo/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/lingogo/logic/parser/EditCommandParserTest.java
@@ -7,6 +7,8 @@ import static lingogo.logic.commands.CommandTestUtil.ENGLISH_PHRASE_DESC_GOOD_MO
 import static lingogo.logic.commands.CommandTestUtil.ENGLISH_PHRASE_DESC_HELLO;
 import static lingogo.logic.commands.CommandTestUtil.INVALID_ENGLISH_PHRASE_DESC;
 import static lingogo.logic.commands.CommandTestUtil.INVALID_FOREIGN_PHRASE_DESC;
+import static lingogo.logic.commands.CommandTestUtil.INVALID_LONG_ENGLISH_PHRASE_DESC;
+import static lingogo.logic.commands.CommandTestUtil.INVALID_LONG_FOREIGN_PHRASE_DESC;
 import static lingogo.logic.commands.CommandTestUtil.LANGUAGE_TYPE_DESC_CHINESE;
 import static lingogo.logic.commands.CommandTestUtil.VALID_CHINESE_PHRASE_GOOD_MORNING;
 import static lingogo.logic.commands.CommandTestUtil.VALID_CHINESE_PHRASE_HELLO;
@@ -67,6 +69,10 @@ public class EditCommandParserTest {
                 Phrase.MESSAGE_CONSTRAINTS); // invalid English phrase
         assertParseFailure(parser, "1" + INVALID_FOREIGN_PHRASE_DESC,
                 Phrase.MESSAGE_CONSTRAINTS); // invalid foreign phrase
+        assertParseFailure(parser, "1" + INVALID_LONG_ENGLISH_PHRASE_DESC,
+                Phrase.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_LONG_FOREIGN_PHRASE_DESC,
+                Phrase.MESSAGE_CONSTRAINTS);
 
         // invalid English phrase followed by valid foreign phrase
         assertParseFailure(parser, "1" + INVALID_ENGLISH_PHRASE_DESC + CHINESE_PHRASE_DESC_GOOD_MORNING,

--- a/src/test/java/lingogo/model/flashcard/PhraseTest.java
+++ b/src/test/java/lingogo/model/flashcard/PhraseTest.java
@@ -19,6 +19,12 @@ public class PhraseTest {
     }
 
     @Test
+    public void constructor_phraseTooLong_throwsIllegalArgumentException() {
+        String longPhrase = "This invalid string is about 51 characters long :(.";
+        assertThrows(IllegalArgumentException.class, () -> new Phrase(longPhrase));
+    }
+
+    @Test
     public void isValidPhrase() {
         // null phrase
         assertThrows(NullPointerException.class, () -> Phrase.isValidPhrase(null));
@@ -28,6 +34,7 @@ public class PhraseTest {
         assertFalse(Phrase.isValidPhrase(" ")); // spaces only
         assertFalse(Phrase.isValidPhrase("Good\nMorning")); // new line not allowed
         assertFalse(Phrase.isValidPhrase(" Good Morning")); // preceding whitespace
+        assertFalse(Phrase.isValidPhrase("This invalid string is about 51 characters long :(.")); // phrase too long
 
         // valid English phrases
         assertTrue(Phrase.isValidPhrase("Good Morning"));
@@ -39,7 +46,7 @@ public class PhraseTest {
         assertTrue(Phrase.isValidPhrase("Good Morning?")); // punctuation: question mark
         assertTrue(Phrase.isValidPhrase("Good_Morning")); // punctuation: underscore
         assertTrue(Phrase.isValidPhrase("Non-stop")); // punctuation: dash
-        assertTrue(Phrase.isValidPhrase("sheesh, i can't believe we are back in lockdown again")); // long phrase
+        assertTrue(Phrase.isValidPhrase("This valid string is exactly 50 characters long :D")); // long phrase
 
         // valid Unicode character phrases
         assertTrue(Phrase.isValidPhrase("你好")); // Chinese, Simplified

--- a/src/test/java/lingogo/model/flashcard/PhraseTest.java
+++ b/src/test/java/lingogo/model/flashcard/PhraseTest.java
@@ -20,7 +20,11 @@ public class PhraseTest {
 
     @Test
     public void constructor_phraseTooLong_throwsIllegalArgumentException() {
-        String longPhrase = "This invalid string is about 51 characters long :(.";
+        String longPhrase = "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaaa";
         assertThrows(IllegalArgumentException.class, () -> new Phrase(longPhrase));
     }
 
@@ -34,7 +38,11 @@ public class PhraseTest {
         assertFalse(Phrase.isValidPhrase(" ")); // spaces only
         assertFalse(Phrase.isValidPhrase("Good\nMorning")); // new line not allowed
         assertFalse(Phrase.isValidPhrase(" Good Morning")); // preceding whitespace
-        assertFalse(Phrase.isValidPhrase("This invalid string is about 51 characters long :(.")); // phrase too long
+        assertFalse(Phrase.isValidPhrase("aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaa"
+                + "aaaaaaaaaaaaaaaaaaaaa")); // phrase too long
 
         // valid English phrases
         assertTrue(Phrase.isValidPhrase("Good Morning"));


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
- Added a **50 character limit** for `Phrase` to prevent GUI text from overflowing and showing `...` when phrases are too long.
- Added tests for checking character limit for `Phrase`.
- Updated UG to reflect this new character limit in the `add` and `edit` commands.

Closes #170.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
- Run the app and add/edit a phrase (English or foreign) that is more than 50 characters long. The command result should show that the phrase has to be 50 characters or less.

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have written testcases to cover all new methods
- [x] I have built and manually tested this code
- [x] I have updated the User Guide
- [ ] I have updated the Developer Guide
- [ ] I have updated my individual project portfolio
- [ ] I have included a preview deployment link to the updated project documentation
