### PR TITLE
Remove redundant slideshow answer command outputs

### DIFF
--- a/src/main/java/lingogo/logic/commands/AnswerCommand.java
+++ b/src/main/java/lingogo/logic/commands/AnswerCommand.java
@@ -29,8 +29,7 @@ public class AnswerCommand extends Command {
     public static final String MESSAGE_USAGE =
             getMessageUsage(COMMAND_WORD, COMMAND_DESCRIPTION, COMMAND_PARAMETERS, COMMAND_EXAMPLES);
 
-    public static final String COMPARISON_TEXT = "Foreign phrase: %1$s\n" + "Expected answer: %2$s\n"
-        + "Your answer: %3$s";
+    public static final String COMPARISON_TEXT = "Expected answer: %1$s\nYour answer: %2$s";
 
     public static final String MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT = "Well done! You got it right!\n"
         + COMPARISON_TEXT;
@@ -66,11 +65,11 @@ public class AnswerCommand extends Command {
         Flashcard currentFlashcard = model.getCurrentSlide();
         if (!predicate.test(currentFlashcard)) {
             return new CommandResult(String.format(MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG,
-                    currentFlashcard.getForeignPhrase(), currentFlashcard.getEnglishPhrase(), givenPhrase));
+                    currentFlashcard.getEnglishPhrase(), givenPhrase));
         }
 
         return new CommandResult(String.format(MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
-                currentFlashcard.getForeignPhrase(), currentFlashcard.getEnglishPhrase(), givenPhrase));
+                currentFlashcard.getEnglishPhrase(), givenPhrase));
     }
 
     @Override

--- a/src/test/java/lingogo/logic/commands/AnswerCommandTest.java
+++ b/src/test/java/lingogo/logic/commands/AnswerCommandTest.java
@@ -36,7 +36,7 @@ public class AnswerCommandTest {
         AnswerCommand answerCommand = new AnswerCommand(validPhraseAfternoon);
 
         String expectedMessage = String.format(AnswerCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
-            flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
+            flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
 
         ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
         expectedModel.startSlideshow();
@@ -57,7 +57,7 @@ public class AnswerCommandTest {
         AnswerCommand answerCommand = new AnswerCommand(validPhraseGoodMorning);
 
         String expectedMessage = String.format(AnswerCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_WRONG,
-            flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_GOOD_MORNING);
+            flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_GOOD_MORNING);
 
         ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
         expectedModel.startSlideshow();
@@ -88,7 +88,7 @@ public class AnswerCommandTest {
         Flashcard flashcardToTest = model.getCurrentSlide();
         AnswerCommand answerCommand = new AnswerCommand(validPhraseAfternoon);
         String expectedMessage = String.format(AnswerCommand.MESSAGE_TEST_FLASHCARD_SUCCESS_CORRECT,
-                flashcardToTest.getForeignPhrase(), flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
+                flashcardToTest.getEnglishPhrase(), VALID_ENGLISH_PHRASE_AFTERNOON);
 
         ModelManager expectedModel = new ModelManager(model.getFlashcardApp(), new UserPrefs());
         expectedModel.startSlideshow();


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->

Previously (the 4th line of output was hidden):
<img width="928" alt="image" src="https://user-images.githubusercontent.com/53928333/140019104-72c4b5d0-4dd5-4a45-83d8-38e348b29a47.png">

Now (after removal of the foreign phrase line): 
<img width="928" alt="image" src="https://user-images.githubusercontent.com/53928333/140019021-1ef31737-4d1c-4879-988a-1d0927812aea.png">

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
Test the above behaviour when running the slideshow answer command for BOTH correct and wrong answers

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] I have built and manually tested this code
~- [ ] I have updated the User Guide~
~- [ ] I have updated the Developer Guide~
~- [ ] I have updated my individual project portfolio~

