### PR TITLE
Edit import commands

### DIFF
--- a/src/main/java/lingogo/logic/commands/ImportCommand.java
+++ b/src/main/java/lingogo/logic/commands/ImportCommand.java
@@ -124,7 +124,16 @@ public class ImportCommand extends Command {
             if (line.length != 3 || line[0].isBlank() || line[1].isBlank() || line[2].isBlank()) {
                 throw new CommandException(String.format(MESSAGE_INVALID_CSV_CONTENT, fileName));
             }
-            Flashcard card = new Flashcard(new LanguageType(line[0]), new Phrase(line[2]), new Phrase(line[1]));
+            String languageType = line[0];
+            String englishPhrase = line[2];
+            String foreignPhrase = line[1];
+            if (!LanguageType.isValidLanguageType(languageType)
+                    || !Phrase.isValidPhrase(englishPhrase)
+                    || !Phrase.isValidPhrase(foreignPhrase)) {
+                throw new CommandException(String.format(MESSAGE_INVALID_CSV_CONTENT, fileName));
+            }
+            Flashcard card = new Flashcard(
+                    new LanguageType(languageType), new Phrase(englishPhrase), new Phrase(foreignPhrase));
             importedFlashcardList.add(card);
         }
     }

--- a/src/main/java/lingogo/logic/parser/ImportCommandParser.java
+++ b/src/main/java/lingogo/logic/parser/ImportCommandParser.java
@@ -19,7 +19,7 @@ public class ImportCommandParser implements Parser<ImportCommand> {
     public ImportCommand parse(String args) throws ParseException {
         String fileName = args.trim();
 
-        if (!fileName.endsWith(".csv")) {
+        if (!fileName.endsWith(".csv") || fileName.contains("\\") || fileName.contains("/")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_CSV_FILE_NAME, fileName));
         }

--- a/src/main/java/lingogo/model/flashcard/LanguageType.java
+++ b/src/main/java/lingogo/model/flashcard/LanguageType.java
@@ -42,7 +42,13 @@ public class LanguageType {
      * Returns the formatted string for language type, where only the first letter is capitalized.
      */
     private static String formatLanguageType(String input) {
-        return input.substring(0, 1).toUpperCase() + input.substring(1).toLowerCase();
+        String[] words = input.split("\\s+");
+        StringBuilder languageType = new StringBuilder("");
+        for (String word : words) {
+            languageType.append(word.substring(0, 1).toUpperCase())
+                    .append(word.substring(1).toLowerCase()).append(" ");
+        }
+        return languageType.substring(0, languageType.length() - 1);
     }
 
     @Override

--- a/src/main/java/lingogo/model/flashcard/LanguageType.java
+++ b/src/main/java/lingogo/model/flashcard/LanguageType.java
@@ -17,6 +17,7 @@ public class LanguageType {
      * {@code \\[a-zA-Z ]*} Allows us to match any alphabet characters 0 or more times.
      */
     public static final String VALIDATION_REGEX = "\\S[a-zA-Z ]*";
+    public static final int MAX_LENGTH = 50;
 
     public final String value;
 
@@ -35,7 +36,7 @@ public class LanguageType {
      * Returns true if a given language type is a valid language type.
      */
     public static boolean isValidLanguageType(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= MAX_LENGTH;
     }
 
     /**

--- a/src/main/java/lingogo/model/flashcard/LanguageType.java
+++ b/src/main/java/lingogo/model/flashcard/LanguageType.java
@@ -12,11 +12,9 @@ public class LanguageType {
             + " and should not be blank";
 
     /**
-     * {@code \\S} The first character of the phrase must not be a whitespace.
-     * This prevents " " (a blank string) from becoming a valid input.
-     * {@code \\[a-zA-Z ]*} Allows us to match any alphabet characters 0 or more times.
+     * {@code \\[a-zA-Z ]*} Allows us to match any alphabet characters or space 0 or more times.
      */
-    public static final String VALIDATION_REGEX = "\\S[a-zA-Z ]*";
+    public static final String VALIDATION_REGEX = "[a-zA-Z][a-zA-Z ]*";
     public static final int MAX_LENGTH = 50;
 
     public final String value;

--- a/src/main/java/lingogo/storage/JsonAdaptedFlashcard.java
+++ b/src/main/java/lingogo/storage/JsonAdaptedFlashcard.java
@@ -54,7 +54,7 @@ class JsonAdaptedFlashcard {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     "Language " + Phrase.class.getSimpleName()));
         }
-        if (!Phrase.isValidPhrase(languageType)) {
+        if (!LanguageType.isValidLanguageType(languageType)) {
             throw new IllegalValueException(Phrase.MESSAGE_CONSTRAINTS);
         }
 

--- a/src/test/java/lingogo/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/lingogo/logic/parser/ImportCommandParserTest.java
@@ -10,8 +10,15 @@ public class ImportCommandParserTest {
     private final ImportCommandParser parser = new ImportCommandParser();
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
+    public void parse_noCsvExtension_throwsParseException() {
         String userInput = "abc";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_CSV_FILE_NAME, userInput));
+    }
+
+    @Test
+    public void parse_containSlashes_throwsParseException() {
+        String userInput = "./abc";
         assertParseFailure(parser, userInput,
                 String.format(MESSAGE_INVALID_CSV_FILE_NAME, userInput));
     }

--- a/src/test/java/lingogo/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/lingogo/logic/parser/ImportCommandParserTest.java
@@ -17,8 +17,15 @@ public class ImportCommandParserTest {
     }
 
     @Test
-    public void parse_containSlashes_throwsParseException() {
+    public void parse_containForwardSlash_throwsParseException() {
         String userInput = "./abc";
+        assertParseFailure(parser, userInput,
+                String.format(MESSAGE_INVALID_CSV_FILE_NAME, userInput));
+    }
+
+    @Test
+    public void parse_containBackSlash_throwsParseException() {
+        String userInput = ".\\abc";
         assertParseFailure(parser, userInput,
                 String.format(MESSAGE_INVALID_CSV_FILE_NAME, userInput));
     }

--- a/src/test/java/lingogo/model/flashcard/LanguageTypeTest.java
+++ b/src/test/java/lingogo/model/flashcard/LanguageTypeTest.java
@@ -28,6 +28,8 @@ public class LanguageTypeTest {
         assertFalse(LanguageType.isValidLanguageType(" ")); // spaces only
         assertFalse(LanguageType.isValidLanguageType("English\n")); // non alphabet not allowed
         assertFalse(LanguageType.isValidLanguageType(" English")); // preceding whitespace
+        assertFalse(LanguageType.isValidLanguageType(
+                "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")); // longer than 50 characters
 
         // valid language type
         assertTrue(LanguageType.isValidLanguageType("English"));

--- a/src/test/java/lingogo/model/flashcard/LanguageTypeTest.java
+++ b/src/test/java/lingogo/model/flashcard/LanguageTypeTest.java
@@ -35,6 +35,7 @@ public class LanguageTypeTest {
         assertFalse(LanguageType.isValidLanguageType(" ")); // spaces only
         assertFalse(LanguageType.isValidLanguageType("English\n")); // non alphabet not allowed
         assertFalse(LanguageType.isValidLanguageType(" English")); // preceding whitespace
+        assertFalse(LanguageType.isValidLanguageType(":English")); // preceding non-alphabet
         assertFalse(LanguageType.isValidLanguageType(
                 "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")); // longer than 50 characters
 

--- a/src/test/java/lingogo/model/flashcard/LanguageTypeTest.java
+++ b/src/test/java/lingogo/model/flashcard/LanguageTypeTest.java
@@ -1,6 +1,7 @@
 package lingogo.model.flashcard;
 
 import static lingogo.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,6 +17,12 @@ public class LanguageTypeTest {
     public void constructor_invalidLanguageType_throwsIllegalArgumentException() {
         String invalidLanguageType = "";
         assertThrows(IllegalArgumentException.class, () -> new LanguageType(invalidLanguageType));
+    }
+
+    @Test
+    public void constructor_capitalize_success() {
+        LanguageType l = new LanguageType("bahasa melayu");
+        assertEquals(l.value, "Bahasa Melayu");
     }
 
     @Test


### PR DESCRIPTION
### Description

- Language Type now has maximum length of 50 characters. It will capitalize the first letter of each word.
- Import command will reject file names containing slashes. It will also check if the CSV file has fields that are in correct format.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### How to test

1. Add a card with language type longer than 50 characters.
2. Add a card with language type consisting of multiple words.
3. Import CSV that is located in a different folder other than `data`.
4. Import CSV file that has a card with language type containing special characters.

### Checklist

- [X] I have written testcases to cover all new methods
- [X] I have built and manually tested this code
