### PR TITLE
Refactor import and export commands and fix Excel CSV UTF-8 encoding bug

### DIFF
--- a/src/main/java/lingogo/commons/core/Messages.java
+++ b/src/main/java/lingogo/commons/core/Messages.java
@@ -11,7 +11,7 @@ public class Messages {
     public static final String MESSAGE_FLASHCARDS_LISTED_OVERVIEW = "%1$d flashcards listed!";
     public static final String MESSAGE_INVALID_CSV_CONTENT = "The flashcards in %1$s are not in the correct format";
     public static final String MESSAGE_INVALID_CSV_HEADERS = "The headers in %1$s are not in the correct format";
-    public static final String MESSAGE_FILE_NOT_FOUND = "%1$s cannot found in the data folder";
+    public static final String MESSAGE_FILE_NOT_FOUND = "%1$s cannot be found in the data folder";
     public static final String MESSAGE_INVALID_CSV_FILE_NAME = "%1$s is not a valid CSV file name";
     public static final String MESSAGE_IN_SLIDESHOW_MODE = "This command can only be run when slideshow mode is not"
             + " active!";

--- a/src/main/java/lingogo/commons/exceptions/CsvColumnHeaderException.java
+++ b/src/main/java/lingogo/commons/exceptions/CsvColumnHeaderException.java
@@ -1,0 +1,7 @@
+package lingogo.commons.exceptions;
+
+public class CsvColumnHeaderException extends Exception {
+    public CsvColumnHeaderException() {
+        super();
+    }
+}

--- a/src/main/java/lingogo/commons/exceptions/CsvNumColumnsException.java
+++ b/src/main/java/lingogo/commons/exceptions/CsvNumColumnsException.java
@@ -1,0 +1,7 @@
+package lingogo.commons.exceptions;
+
+public class CsvNumColumnsException extends Exception {
+    public CsvNumColumnsException() {
+        super();
+    }
+}

--- a/src/main/java/lingogo/commons/util/FileUtil.java
+++ b/src/main/java/lingogo/commons/util/FileUtil.java
@@ -1,11 +1,27 @@
 package lingogo.commons.util;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
+
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.CSVWriter;
+import com.opencsv.exceptions.CsvValidationException;
+
+import lingogo.commons.exceptions.CsvColumnHeaderException;
+import lingogo.commons.exceptions.CsvNumColumnsException;
 
 /**
  * Writes and reads files
@@ -13,6 +29,7 @@ import java.util.regex.Pattern;
 public class FileUtil {
 
     private static final String CHARSET = "UTF-8";
+    private static final String UTF8_BOM = "\uFEFF"; // the UTF-8 byte order mark (BOM)
 
     public static boolean isFileExists(Path file) {
         return Files.exists(file) && Files.isRegularFile(file);
@@ -94,6 +111,80 @@ public class FileUtil {
                 && !specialChars.matcher(fileName).find()
                 && !reservedNames.matcher(fileName.replace(".csv", "")).matches()
                 && fileName.length() < 32;
+    }
+
+    /**
+     * Returns a List of String[] representing the CSV file content at the specified
+     * filepath. Each element of the List contains a row of data in the CSV file.
+     *
+     * @param filepath A string representing the file path. Cannot be null.
+     * @param expectedHeaders The expected headers in the CSV file.
+     * @throws IOException If an error occurs during the read.
+     * @throws CsvValidationException When the CSV file is not valid.
+     * @throws CsvColumnHeaderException When the headers of the CSV file do not match expectedHeaders.
+     * @throws CsvNumColumnsException When the number of columns in the CSV file does not match the
+     * length of expectedHeaders.
+     */
+    public static List<String[]> importCsvFileContent(String filepath, String[] expectedHeaders)
+            throws IOException, CsvValidationException, CsvColumnHeaderException, CsvNumColumnsException {
+        CSVReader reader = new CSVReaderBuilder(
+                new InputStreamReader(new FileInputStream(filepath), StandardCharsets.UTF_8)).build();
+
+        String[] headers = reader.readNext();
+
+        // Handle empty CSV file
+        if (headers == null) {
+            throw new CsvColumnHeaderException();
+        }
+
+        // Handle UTF-8 byte order mark
+        if (headers.length > 0 && headers[0].startsWith(UTF8_BOM)) {
+            headers[0] = headers[0].substring(1);
+        }
+
+        // Validate headers
+        if (!Arrays.toString(headers).equals(Arrays.toString(expectedHeaders))) {
+            throw new CsvColumnHeaderException();
+        }
+
+        ArrayList<String[]> output = new ArrayList<>();
+        String[] line;
+        int expectedNumberOfColumns = expectedHeaders.length;
+
+        while ((line = reader.readNext()) != null) {
+            if (line.length != expectedNumberOfColumns || Arrays.asList(line).stream().anyMatch(e -> e.isBlank())) {
+                throw new CsvNumColumnsException();
+            }
+
+            output.add(line);
+        }
+
+        return output;
+    }
+
+    /**
+     * Exports the given headers and content into a CSV file at the specified filepath.
+     *
+     * @param filepath The filepath where the CSV file will be created at.
+     * @param headers The headers to be written into the CSV file.
+     * @param content The content to be written into the CSV file. Each element of the List contains a row of data.
+     * @throws IOException When an IO error occurs when writing to the specified file.
+     */
+    public static void exportToCsvFile(String filepath, String[] headers, List<String[]> content)
+            throws IOException {
+        FileOutputStream w = new FileOutputStream(filepath);
+
+        // Add the byte order mark (BOM) for UTF-8 encoding. This is necessary for certain software
+        // (e.g. Excel) to read the CSV file correctly
+        w.write(0xef);
+        w.write(0xbb);
+        w.write(0xbf);
+
+        CSVWriter writer = new CSVWriter(new OutputStreamWriter(w, StandardCharsets.UTF_8));
+
+        writer.writeNext(headers);
+        writer.writeAll(content);
+        writer.close();
     }
 
 }

--- a/src/main/java/lingogo/logic/commands/ImportCommand.java
+++ b/src/main/java/lingogo/logic/commands/ImportCommand.java
@@ -42,6 +42,9 @@ public class ImportCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "LingoGO! has been updated with all the flashcards from %1$s";
 
+    public static final String MESSAGE_NO_CSV_ROW_ENTRIES_DETECTED = "There are no CSV row entries detected in %1$s!"
+            + " Please recheck your CSV file!";
+
     public static final String MESSAGE_NOT_UPDATED =
             "LingoGO! already contains all the flashcards you are importing from %1$s";
 
@@ -84,6 +87,11 @@ public class ImportCommand extends Command {
             throw new CommandException(String.format(MESSAGE_INVALID_CSV_CONTENT, fileName));
         } catch (IOException ioe) {
             throw new CommandException(String.format(IMPORT_IOEXCEPTION, fileName));
+        }
+
+        // No CSV row entries detected
+        if (content.size() == 0) {
+            throw new CommandException(String.format(MESSAGE_NO_CSV_ROW_ENTRIES_DETECTED, fileName));
         }
 
         // Validate that all CSV row entries make up valid flashcards

--- a/src/test/data/SampleCsvFiles/noRowEntries.csv
+++ b/src/test/data/SampleCsvFiles/noRowEntries.csv
@@ -1,0 +1,1 @@
+Language,Foreign,English

--- a/src/test/java/lingogo/logic/commands/ImportCommandTest.java
+++ b/src/test/java/lingogo/logic/commands/ImportCommandTest.java
@@ -107,6 +107,25 @@ public class ImportCommandTest {
     }
 
     @Test
+    public void execute_validHeadersButNoRowContent_throwsCommandException() {
+        createDataFolder();
+        String fileName = "noRowEntries.csv";
+        try {
+            createCopyInDataFolder(fileName);
+        } catch (Exception e) {
+            fail("Exception not expected");
+        }
+        String expectedMessage = String.format(ImportCommand.MESSAGE_NO_CSV_ROW_ENTRIES_DETECTED, fileName);
+        ImportCommand command = new ImportCommand(fileName);
+        assertCommandFailure(command, model, expectedMessage);
+        try {
+            deleteCopyInDataFolder(fileName);
+        } catch (Exception e) {
+            fail("Exception not expected");
+        }
+    }
+
+    @Test
     public void execute_importDuplicateContent_noNewFlashcards() {
         createDataFolder();
         String fileName = "duplicateContent.csv";


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
1. Exporting a CSV file from Excel in CSV UTF-8 format should now be imported correctly into the app
2. CSV files obtained via our export command should now open in Excel without issue
3. Refactored and abstracted CSV methods into FileUtil.java

TODO: Documentation updates for both UG and DG

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvements

### How to test
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
##### Import command
Positive test cases:
- [ ] Valid headers and rows
- [ ] Only headers, no actual rows

Negative test cases:
- [ ] Invalid headers
- [ ] Completely empty file
- [ ] Blank rows inbetween rows
- [ ] Trailing (> 1) or leading (> 0) empty rows
- [ ] >100 chars phrases
- [ ] >50 chars language
- [ ] non-alphabetical language
- [ ] No actual `data` directory
- [ ] No actual corresponding file
- [ ] Non CSV file (e.g. Excel file)

##### Export command
Positive test cases:
- [ ] Actual flashcards
- [ ] No flashcards
- [ ] No `data` directory

Negative test cases:
- [ ] To check what happens if no OS permissions to create file

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have written testcases to cover all new methods
- [x] I have built and manually tested this code
- [ ] I have updated the User Guide
- [ ] I have updated the Developer Guide
- [ ] I have updated my individual project portfolio

