### PR TITLE
Add more height for long phrases

### DIFF
--- a/src/main/java/lingogo/ui/FlashcardPane.java
+++ b/src/main/java/lingogo/ui/FlashcardPane.java
@@ -13,6 +13,7 @@ import lingogo.model.flashcard.Flashcard;
 public class FlashcardPane extends UiPart<Region> {
 
     private static final String FXML = "FlashcardPane.fxml";
+    private static final int LARGE_PHRASE_PADDING = 30;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
@@ -49,10 +50,12 @@ public class FlashcardPane extends UiPart<Region> {
         foreignPhrase.setWrappingWidth(cardPane.getColumnConstraints().get(2).getPrefWidth());
         englishPhrase.setWrappingWidth(cardPane.getColumnConstraints().get(3).getPrefWidth());
 
+        // If the English or foreign phrase or both are very long, the flashcard pane will need more height to display
+        // all the text
         double heightNeeded =
-                Math.max(foreignPhrase.getLayoutBounds().getHeight(), englishPhrase.getLayoutBounds().getHeight());
-        cardPane.setMinHeight(
-                Math.max(foreignPhrase.getLayoutBounds().getHeight(), englishPhrase.getLayoutBounds().getHeight()));
+                Math.max(foreignPhrase.getLayoutBounds().getHeight(), englishPhrase.getLayoutBounds().getHeight())
+                + LARGE_PHRASE_PADDING;
+        cardPane.setMinHeight(heightNeeded);
         if (cardPane.getPrefHeight() < heightNeeded) {
             cardPane.setPrefHeight(heightNeeded);
         }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
Added padding for phrases on flashcards that have long phrases so that text is properly contained within the flashcard display pane.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements

### How to test

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->
Add a flashcard with an English/foreign phrase that is 100 characters long. The text should be contained within the flashcard pane in list mode.

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] I have written testcases to cover all new methods
- [x] I have built and manually tested this code
- [ ] I have updated the User Guide
- [ ] I have updated the Developer Guide
- [ ] I have updated my individual project portfolio
- [ ] I have included a preview deployment link to the updated project documentation
